### PR TITLE
Modified tag_box

### DIFF
--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -1,8 +1,11 @@
 use crate::widgets::Tag;
 
+use gio::prelude::Cast;
 use gtk4::{
-    gdk::Display, prelude::WidgetExt, style_context_add_provider_for_display, Align, Box,
-    CssProvider, Label, Orientation, STYLE_PROVIDER_PRIORITY_APPLICATION,
+    gdk::Display,
+    prelude::{BoxExt, WidgetExt},
+    style_context_add_provider_for_display, Align, Box, CssProvider, Label, Orientation, Widget,
+    STYLE_PROVIDER_PRIORITY_APPLICATION,
 };
 
 /// Creates a new GTK4 `Label` with a specified CSS class name.
@@ -15,11 +18,29 @@ pub fn tag_label(class_name: &str) -> Tag {
 }
 
 /// Creates a new GTK4 `Box` with a specified CSS class name.
-pub fn tag_box(class_name: &str) -> Tag {
-    let tag = Box::new(Orientation::Vertical, 0);
+pub fn tag_box(class_name: &str, orientation: &str, spacing: i32, widgets: Vec<Tag>) -> Tag {
+    let orientation = match orientation {
+        "v" => Orientation::Vertical,
+        "h" => Orientation::Horizontal,
+        "vertical" => Orientation::Vertical,
+        "horizontal" => Orientation::Horizontal,
+        _ => Orientation::Vertical,
+    };
 
+    let tag = Box::new(orientation, spacing);
     tag.set_widget_name(class_name);
+    let widgets: Vec<Widget> = widgets
+        .into_iter()
+        .map(|tag| match tag {
+            Tag::Label(label) => label.clone().upcast::<Widget>(),
+            Tag::Box(box_) => box_.clone().upcast::<Widget>(),
+            Tag::Button(button) => button.clone().upcast::<Widget>(),
+        })
+        .collect();
 
+    for widget in widgets {
+        tag.append(&widget);
+    }
     Tag::Box(tag)
 }
 

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -17,7 +17,7 @@ pub fn tag_label(class_name: &str) -> Tag {
     Tag::Label(tag)
 }
 
-/// Creates a new GTK4 `Box` with a specified CSS class name.
+/// Creates a new GTK4 `Box` with a specified CSS class name, orientation and spacing.
 pub fn tag_box(class_name: &str, orientation: &str, spacing: i32, widgets: Vec<Tag>) -> Tag {
     let orientation = match orientation {
         "v" => Orientation::Vertical,


### PR DESCRIPTION
Following [this](https://github.com/drkrssll/chunks-rs/discussions/3) opened discussion, this PR modify the `tag_box` fn while maintaining its previous functionality, it can also do the following:-
1. Take orientation, spacing and other tags as arguments.
Unfortunately, this also compels the user to specify orientation and spacing every time it is used, as rust doesn't have optional and default args (obviously).

It can e used with an `GtkApp` function as following:
```
fn helloworld(factory: &GtkApp) {
    let tag_label_hello = tag_label("storage");
    let tag_label_world = tag_label("storage");
    let margins = vec![(Edge::Top, 20), (Edge::Right, 160)];
    let anchors = EdgeConfig::TOP_RIGHT.to_vec();

    Internal::static_widget(&tag_label_hello, "hello");
    Internal::static_widget(&tag_label_world, "world");

    let tag = tag_box("storage", "h", 9, vec![tag_label_hello, tag_label_world]);

    Chunk::new(
        factory.clone(),
        "Storage",
        tag,
        margins,
        anchors,
        Layer::Top,
    )
    .build();
}

```