### PR TITLE
Revealfix: Fixes window resize in revealer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Chunks-rs
 [![Crates.io](https://img.shields.io/crates/d/chunks-rs?style=flat-square&color=red)](https://crates.io/crates/chunks-rs)
-
-### Special Thanks to:
-- [Bhaumik](https://github.com/bhaumik-tripathi), for helping me see beyond my own desires for this project.
-
 ## Description
 
 A library that simplifies the process of making widgets for Wayland Compositors.
@@ -202,3 +198,6 @@ fn main() {
     factory.pollute_with_args(chunks, args);
 }
 ```
+
+### Special Thanks to:
+- [Bhaumik](https://github.com/VimYoung), for helping me see beyond my own desires for this project.

--- a/src/widgets/chunk.rs
+++ b/src/widgets/chunk.rs
@@ -68,6 +68,7 @@ impl Builder for Chunk {
             .resizable(self.resize)
             .build();
 
+        chunk.set_default_size(1, 1);
         if Wayland::detect_wayland() {
             let wayland = Wayland::new(chunk.clone(), self.anchors, self.margins, self.layer);
 


### PR DESCRIPTION
This PR fixes #7. It doesn't attempt to fix the issue by getting the dimension state of widget,rather it makes the default size to be smaller, making the widget to resize.
I have also updated README to place Thanks section in the bottom, Showcasing your project's features and scope is more important. I had also updated the link(since, I changed my username). :)

Here is a preview after fix

https://github.com/user-attachments/assets/49c320f3-6dd3-4b16-865f-674ef392e86c




