### PR TITLE
WIP: Addition of scroll widget.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "chunks-rs"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "chrono",
  "dbus",

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -7,7 +7,7 @@ use dbus::blocking::Connection;
 use gio::glib::ControlFlow;
 use gtk4::{
     glib::timeout_add_seconds_local,
-    prelude::{BoxExt, ButtonExt, WidgetExt},
+    prelude::{BoxExt, ButtonExt},
     Picture,
 };
 use networkmanager::{

--- a/src/taskbar/bar.rs
+++ b/src/taskbar/bar.rs
@@ -51,6 +51,7 @@ impl Builder for Bar {
                 Tag::Box(box_) => box_.clone().upcast::<Widget>(),
                 Tag::Button(button) => button.clone().upcast::<Widget>(),
                 Tag::Revealer(revealer) => revealer.clone().upcast::<Widget>(),
+                Tag::Scroller(scroller) => scroller.clone().upcast::<Widget>(),
                 Tag::Undefined => panic!("Tag is undefined!"),
             };
 

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -5,7 +5,7 @@ use gtk4::{
     gdk::Display,
     prelude::{BoxExt, WidgetExt},
     style_context_add_provider_for_display, Align, Box, Button, CssProvider, Label, Orientation,
-    Revealer, RevealerTransitionType, Widget, STYLE_PROVIDER_PRIORITY_APPLICATION,
+    Revealer, RevealerTransitionType, ScrolledWindow, Widget, STYLE_PROVIDER_PRIORITY_APPLICATION,
 };
 
 /// Creates a new GTK4 `Label` with a specified CSS class name.
@@ -46,6 +46,7 @@ pub fn tag_container(
             Tag::Box(box_) => box_.clone().upcast::<Widget>(),
             Tag::Button(button) => button.clone().upcast::<Widget>(),
             Tag::Revealer(revealer) => revealer.clone().upcast::<Widget>(),
+            Tag::Scroller(scroller) => scroller.clone().upcast::<Widget>(),
             Tag::Undefined => panic!("Tag is undefined!"),
         })
         .collect();
@@ -90,6 +91,22 @@ pub fn tag_revealer(
     Tag::Revealer(tag)
 }
 
+pub fn tag_scroller(class_name: &str, child: Tag, _vscroll: bool, _hscroll: bool) -> Tag {
+    let tag = ScrolledWindow::new();
+    // tag.set_max_content_width(60);
+    // tag.set_max_content_height(20);
+    tag.set_widget_name(class_name);
+    match child {
+        Tag::Box(box_) => tag.set_child(Some(&box_)),
+        Tag::Label(label) => tag.set_child(Some(&label)),
+        Tag::Button(button) => tag.set_child(Some(&button)),
+        Tag::Revealer(revealer) => tag.set_child(Some(&revealer)),
+        _ => return Tag::Undefined,
+    }
+    println!("{:?}", tag.hadjustment());
+    Tag::Scroller(tag)
+}
+
 /// Positions a GTK4 `Tag` (for use inside of Bar)
 // private because it doesnt work? (or i dont know what im doing)
 // fuck it, ill just use CSS for this shit anyways
@@ -110,6 +127,10 @@ fn tag_position(tag: &Tag, x: Align, y: Align) {
         Tag::Revealer(revealer) => {
             revealer.set_halign(x);
             revealer.set_valign(y);
+        }
+        Tag::Scroller(scroller) => {
+            scroller.set_halign(x);
+            scroller.set_valign(y);
         }
         Tag::Undefined => {
             panic!("Tag is undefined!");

--- a/src/widgets/plate.rs
+++ b/src/widgets/plate.rs
@@ -48,6 +48,7 @@ impl Builder for Plate {
             Tag::Box(box_) => box_.upcast::<Widget>(),
             Tag::Button(button) => button.upcast::<Widget>(),
             Tag::Revealer(revealer) => revealer.upcast::<Widget>(),
+            Tag::Scroller(scroller) => scroller.clone().upcast::<Widget>(),
             Tag::Undefined => panic!("Tag is undefined!"),
         };
 

--- a/src/widgets/slab.rs
+++ b/src/widgets/slab.rs
@@ -70,6 +70,7 @@ impl Builder for Slab {
             Tag::Box(box_) => box_.upcast::<Widget>(),
             Tag::Button(button) => button.upcast::<Widget>(),
             Tag::Revealer(revealer) => revealer.upcast::<Widget>(),
+            Tag::Scroller(scroller) => scroller.clone().upcast::<Widget>(),
             Tag::Undefined => panic!("Tag is undefined!"),
         };
 


### PR DESCRIPTION
I request you not to merge this PR as I have not yet implemented 2 arguments of scroller. It also contains some breaking changes for chunks. So, I have made the following changes.
1. Added the availability of scrollable widget.
2. Dimentions requested by the `ScrollWindow` gtk widget combined with `chunk.set_default_size(1, 1);` was casing the scroll to shrink to the smallest size possible, thus I had to add a workaround by providing custom dimentions in chunks. After the implementation of `hscroll` and `vscroll` arguments in `tag_scroller` implementation, this issue should be resolved, then if, say, `hscroll` is set to `false`, then I would need the scroll to request the height wanted by its child. This is a WIP. Doc strings is also a to do.

>Note: existing implementations of chunks can still work by adding `-1` in place of `width` and `height`.

As for a minimal working example, following code is working well
```rust
pub fn scroller_text(factory: &GtkApp) {
    let margins = vec![(Edge::Top, 20), (Edge::Right, 160)];
    let anchors = EdgeConfig::TOP_RIGHT.to_vec();

    let text1 = tag_label("storage");
    let text2 = tag_label("storage");
    let text3 = tag_label("storage");
    let text4 = tag_label("storage");
    let text5 = tag_label("storage");
    let text6 = tag_label("storage");
    let text7 = tag_label("storage");
    let text8 = tag_label("storage");

    Internal::static_widget(&text1, "THis is my first sentence.");
    Internal::static_widget(&text2, "THis is my first sentence.");
    Internal::static_widget(&text3, "THis is my first sentence.");
    Internal::static_widget(&text4, "THis is my first sentence.");
    Internal::static_widget(&text5, "THis is my first sentence.");
    Internal::static_widget(&text6, "THis is my first sentence.");
    Internal::static_widget(&text7, "THis is my first sentence.");
    Internal::static_widget(&text8, "THis is my first sentence.");

    let boxx = tag_container(
        "storage",
        Orientation::Vertical,
        20,
        vec![text1, text2, text3, text4, text5, text6, text7, text8],
    );

    Chunk::new(
        factory.clone(),
        "Storage",
        tag_scroller("Storage", boxx, false, false),
        400,
        200,
        margins,
        anchors,
        Layer::Top,
        true,
    )
    .build();
}
```
I would like to have your opinion on this because if you agree on accepting this PR, exisitng examples in readme needs to be updated.


https://github.com/user-attachments/assets/9f120892-b0c0-444b-9904-fb3af6f59530

